### PR TITLE
feat: Implement Phase 4 Local Persistence and Sync Logic

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, View } from 'react-native';
 import { Slot, useRouter, useSegments } from 'expo-router';
 import { PaperProvider } from 'react-native-paper';
 import { AuthProvider, useAuth } from '../src/contexts/AuthContext'; // Adjusted path
+import { SyncProvider } from '../src/contexts/SyncContext'; // Import SyncProvider
 import theme from '../src/theme/theme'; // Import the custom theme
 
 // Main layout component that decides which navigator to show
@@ -40,7 +41,9 @@ export default function RootLayout() {
   return (
     <PaperProvider theme={theme}>
       <AuthProvider>
-        <MainLayout />
+        <SyncProvider>
+          <MainLayout />
+        </SyncProvider>
       </AuthProvider>
     </PaperProvider>
   );

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -1,10 +1,11 @@
-import { SyncState } from '../models/types';
+import React, { createContext, useContext, useReducer, useEffect, ReactNode, useCallback } from 'react'; // Added useCallback
+import NetInfo from '@react-native-community/netinfo';
+import { SyncState, Execucao } from '../models/types'; // Added Execucao
+import { StorageService } from '../services/storageService';
 
 // Definição das ações do reducer
 type SyncAction =
-    | {
-        isOnline: boolean; type: 'SET_CONNECTIVITY'; isConnected: boolean
-    }
+    | { type: 'SET_CONNECTIVITY'; isOnline: boolean } // Corrected: isConnected to isOnline
     | { type: 'SET_SYNCING'; isSyncing: boolean }
     | { type: 'SYNC_SUCCESS'; lastSyncDate: string }
     | { type: 'SYNC_ERROR'; error: string }
@@ -14,7 +15,7 @@ type SyncAction =
 // Estado inicial de sincronização
 const initialState: SyncState = {
     isSyncing: false,
-    isOnline: false,
+    isOnline: false, // Assuming default connectivity is offline
     lastSyncDate: null,
     pendingItems: 0,
     error: null,
@@ -36,6 +37,7 @@ const syncReducer = (state: SyncState, action: SyncAction): SyncState => {
         case 'SYNC_SUCCESS':
             return {
                 ...state,
+                isSyncing: false, // Also set isSyncing to false on success
                 lastSyncDate: action.lastSyncDate,
                 error: null,
             };
@@ -57,14 +59,131 @@ const syncReducer = (state: SyncState, action: SyncAction): SyncState => {
             };
         default:
             return state;
-    };
+    }
+};
 
-    // Definição do contexto de sincronização
-    type SyncContextType = {
-        state: SyncState;
-        sincronizarExecucoes: () => Promise<void>;
-        atualizarPendingCount: () => Promise<void>;
-        clearError: () => void;
-    };
+// Definição do contexto de sincronização
+type SyncContextType = {
+    state: SyncState;
+    sincronizarExecucoes: () => Promise<void>;
+    atualizarPendingCount: () => Promise<void>;
+    clearError: () => void;
+};
 
-}
+// Criação do Contexto
+const SyncContext = createContext<SyncContextType | undefined>(undefined);
+
+// Props do Provider
+type SyncProviderProps = {
+    children: ReactNode;
+};
+
+// Componente Provider
+export const SyncProvider: React.FC<SyncProviderProps> = ({ children }) => {
+    const [state, dispatch] = useReducer(syncReducer, initialState);
+
+    const clearError = useCallback(() => {
+        dispatch({ type: 'CLEAR_ERROR' });
+    }, [dispatch]);
+
+    const atualizarPendingCount = useCallback(async () => {
+        try {
+            const count = await StorageService.obterContagemPendentes();
+            dispatch({ type: 'SET_PENDING_COUNT', count });
+        } catch (error) {
+            console.error("Error fetching pending count:", error);
+            dispatch({ type: 'SYNC_ERROR', error: 'Failed to fetch pending count' });
+        }
+    }, [dispatch]);
+
+    const sincronizarExecucoes = useCallback(async () => {
+        if (!state.isOnline || state.isSyncing) {
+            console.log('Sync skipped: Offline or already syncing.', { isOnline: state.isOnline, isSyncing: state.isSyncing });
+            return;
+        }
+
+        dispatch({ type: 'SET_SYNCING', isSyncing: true });
+        console.log('Starting synchronization...');
+
+        try {
+            const todasExecucoes: Execucao[] = await StorageService.obterExecucoes();
+            const pendentes = todasExecucoes.filter(
+                (e: Execucao) => !e.sincronizado || e.status === 'pendente' || e.status === 'alterado'
+            );
+
+            if (pendentes.length === 0) {
+                console.log('No pending items to sync.');
+                // dispatch({ type: 'SET_SYNCING', isSyncing: false }); // Handled by finally
+                return;
+            }
+
+            console.log(`Syncing ${pendentes.length} items...`);
+            for (const execucao of pendentes) {
+                console.log(`Attempting to sync item: ${execucao.id}`);
+                await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
+                await StorageService.atualizarStatusSincronizacao(execucao.id, true); // True for success
+                console.log('Execução sincronizada:', execucao.id);
+            }
+
+            dispatch({ type: 'SYNC_SUCCESS', lastSyncDate: new Date().toISOString() });
+            await atualizarPendingCount();
+            console.log('Synchronization successful.');
+
+        } catch (error) {
+            console.error('Erro durante sincronização:', error);
+            dispatch({
+                type: 'SYNC_ERROR',
+                error: (error instanceof Error ? error.message : 'Erro desconhecido durante a sincronização')
+            });
+        } finally {
+            dispatch({ type: 'SET_SYNCING', isSyncing: false });
+            console.log('Synchronization process finished.');
+        }
+    }, [state.isOnline, state.isSyncing, dispatch, atualizarPendingCount]);
+
+    // Effect for initial data load (e.g., pending count)
+    useEffect(() => {
+        atualizarPendingCount();
+    }, [atualizarPendingCount]); // Updated dependency
+
+    // Effect for network connectivity
+    useEffect(() => {
+        // Fetch initial network state
+        NetInfo.fetch().then(netState => {
+            dispatch({ type: 'SET_CONNECTIVITY', isOnline: !!(netState.isConnected && netState.isInternetReachable) });
+        });
+
+        // Subscribe to network state changes
+        const unsubscribe = NetInfo.addEventListener(netState => {
+            dispatch({ type: 'SET_CONNECTIVITY', isOnline: !!(netState.isConnected && netState.isInternetReachable) });
+        });
+
+        // Cleanup subscription on unmount
+        return () => {
+            unsubscribe();
+        };
+    }, [dispatch]);
+
+    // Effect for automatic synchronization trigger
+    useEffect(() => {
+        if (state.isOnline && state.pendingItems > 0 && !state.isSyncing) {
+            console.log('Auto-sync triggered.');
+            sincronizarExecucoes();
+        }
+    }, [state.isOnline, state.pendingItems, state.isSyncing, sincronizarExecucoes]);
+
+    return (
+        <SyncContext.Provider value={{ state, sincronizarExecucoes, atualizarPendingCount, clearError }}>
+            {children}
+        </SyncContext.Provider>
+    );
+};
+
+// Hook customizado para usar o SyncContext
+export const useSync = () => {
+    const context = useContext(SyncContext);
+    if (context === undefined) {
+        throw new Error('useSync must be used within a SyncProvider');
+    }
+    return context;
+};


### PR DESCRIPTION
This commit introduces the core functionalities for Phase 4: Local Persistence and Sending.

Key implementations include:

1.  **`SyncContext.tsx`:**
    *   I completed the `SyncContext`, `SyncProvider`, and `useSync` hook.
    *   I integrated `@react-native-community/netinfo` for real-time network connectivity detection, updating an `isOnline` state.
    *   I implemented the `sincronizarExecucoes` function, which:
        *   Checks for online status and existing sync operations.
        *   Fetches pending records from `StorageService`.
        *   Simulates API calls to "send" records (actual API calls are for Phase 5).
        *   Updates the local status of records (`sincronizado: true`, `status: 'enviado'`) via `StorageService.atualizarStatusSincronizacao` upon successful "send".
        *   Manages `isSyncing`, `lastSyncDate`, and `error` states.
    *   I added an automatic trigger for `sincronizarExecucoes` when the app comes online and has pending items.
    *   Relevant functions (`sincronizarExecucoes`, `atualizarPendingCount`, `clearError`) are memoized with `useCallback`.
    *   The context initializes and updates a `pendingItems` count from `StorageService`.

2.  **`StorageService.ts`:**
    *   This utilizes `AsyncStorage` to save, retrieve, update, and delete 'Execucao' records.
    *   It includes methods to update synchronization status (`atualizarStatusSincronizacao`) and count pending items (`obterContagemPendentes`).
    *   The `Execucao` type in `models/types.ts` supports `status` and `sincronizado` fields.

3.  **Application Integration:**
    *   I wrapped the root layout (`app/_layout.tsx`) with `SyncProvider` to make the sync state and functions available globally.

4.  **UI for `PendingScreen` (Partial):**
    *   The code to display sync status (pending items, online status, syncing indicator) on the `PendingScreen` was generated and is located in `app/temp_pending.tsx`.
    *   Due to some limitations with file paths containing parentheses, I could not automatically write this content to `app/(app)/(tabs)/pending.tsx`. You will need to manually integrate this file's content into the actual `PendingScreen` component.

This completes the client-side logic for local data persistence, offline capabilities, and automatic data synchronization when connectivity is restored, setting the stage for Phase 5 (Backend Integration).